### PR TITLE
Frontend timezone fixes

### DIFF
--- a/web/src/components/overlay/ReviewActivityCalendar.tsx
+++ b/web/src/components/overlay/ReviewActivityCalendar.tsx
@@ -50,7 +50,7 @@ export default function ReviewActivityCalendar({
         }
 
         const parts = date.split("-");
-        const cal = new TZDate(date, timezone);
+        const cal = new TZDate(date + "T00:00:00", timezone);
 
         cal.setFullYear(
           parseInt(parts[0]),
@@ -70,7 +70,7 @@ export default function ReviewActivityCalendar({
         }
 
         const parts = date.split("-");
-        const cal = new TZDate(date, timezone);
+        const cal = new TZDate(date + "T00:00:00", timezone);
 
         cal.setFullYear(
           parseInt(parts[0]),

--- a/web/src/views/system/StorageMetrics.tsx
+++ b/web/src/views/system/StorageMetrics.tsx
@@ -80,7 +80,7 @@ export default function StorageMetrics({
   const formattedEarliestDate = useFormattedTimestamp(
     earliestDate || 0,
     format,
-    timezone,
+    "UTC", // timezone is already converted from recordings summary endpoint
   );
 
   if (!cameraStorage || !stats || !totalStorage || !config) {


### PR DESCRIPTION
Last recording date timezone was being applied twice, so it displayed the wrong date Also, TZDate from react-day-picker could have been behaving incorrectly at times without a full date string

## Proposed change
<!--
  Thank you!

  If you're introducing a new feature or significantly refactoring existing functionality,
  we encourage you to start a discussion first. This helps ensure your idea aligns with
  Frigate's development goals.

  Describe what this pull request does and how it will benefit users of Frigate.
  Please describe in detail any considerations, breaking changes, etc. that are
  made in this pull request.
-->


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code
- [ ] Documentation Update

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] UI changes including text have used i18n keys and have been added to the `en` locale.
- [ ] The code has been formatted using Ruff (`ruff format frigate`)
